### PR TITLE
A0-3582: Deal with block limit

### DIFF
--- a/substrate/client/state-db/src/lib.rs
+++ b/substrate/client/state-db/src/lib.rs
@@ -22,7 +22,6 @@
 //! Canonicalization window tracks a tree of blocks identified by header hash. The in-memory
 //! overlay allows to get any trie node that was inserted in any of the blocks within the window.
 //! The overlay is journaled to the backing database and rebuilt on startup.
-//! There's a limit of 32 blocks that may have the same block number in the canonicalization window.
 //!
 //! Canonicalization function selects one root from the top of the tree and discards all other roots
 //! and their subtrees. Upon canonicalization all trie nodes that were inserted in the block are

--- a/substrate/client/state-db/src/lib.rs
+++ b/substrate/client/state-db/src/lib.rs
@@ -135,8 +135,6 @@ pub enum StateDbError {
 	InvalidParent,
 	/// Invalid pruning mode specified. Contains expected mode.
 	IncompatiblePruningModes { stored: PruningMode, requested: PruningMode },
-	/// Too many unfinalized sibling blocks inserted.
-	TooManySiblingBlocks { number: u64 },
 	/// Trying to insert existing block.
 	BlockAlreadyExists,
 	/// Invalid metadata
@@ -187,9 +185,6 @@ impl fmt::Debug for StateDbError {
 				"Incompatible pruning modes [stored: {:?}; requested: {:?}]",
 				stored, requested
 			),
-			Self::TooManySiblingBlocks { number } => {
-				write!(f, "Too many sibling blocks at #{number} inserted")
-			},
 			Self::BlockAlreadyExists => write!(f, "Block already exists"),
 			Self::Metadata(message) => write!(f, "Invalid metadata: {}", message),
 			Self::BlockUnavailable => {

--- a/substrate/client/state-db/src/noncanonical.rs
+++ b/substrate/client/state-db/src/noncanonical.rs
@@ -30,6 +30,7 @@ use std::collections::{hash_map::Entry, BTreeSet, HashMap, VecDeque};
 const NON_CANONICAL_JOURNAL: &[u8] = b"noncanonical_journal";
 pub(crate) const LAST_CANONICAL: &[u8] = b"last_canonical";
 const OVERLAY_LEVEL_SPAN: &[u8] = b"noncanonical_overlay_span";
+/// Threshold for storing overlay level span in db.
 /// To decrease the number of database operations, the span of some overlay
 /// level will be committed to the database iff span > `OVERLAY_LEVEL_STORE_SPANS_LONGER_THAN`
 const OVERLAY_LEVEL_STORE_SPANS_LONGER_THAN: u64 = 32;


### PR DESCRIPTION
# Description

PR removing the limit of 32 blocks on the same level (having the same number) in substrate. This limit is enforced only by one some component of `state-db` that keeps imported, noncanonicalized blocks and it seems it is only enforced for the sake of simpler implementation in https://github.com/paritytech/substrate/pull/8494.

This PR removes that limit by applying the suggestion in the introducing PR, by keeping the span (length) of the overlay level in noncanonicalized blocks. To avoid making extra db queries, the span is kept only if we have more than 32 blocks on the same level (should be an extremely rare case, as these blocks are validated). Moreover, blocks on one were previously indexed on overlay level using a bitmask of length 64. This is changed now to keeping an ordered set of unused indices, adding an `O(log b)` overhead, where |b| is the number of blocks on the same level.

Tested in aleph-node on test client (using db backend) - successfully imported 10k blocks on the same level, and then finalized the last one. It took 8.01s on my laptop, while, for comparison, importing a branch of 10k blocks took 6.39s.