### PR TITLE
A0-4022: Reduced multi block contract migration weight by 4

### DIFF
--- a/substrate/frame/contracts/src/lib.rs
+++ b/substrate/frame/contracts/src/lib.rs
@@ -412,7 +412,12 @@ pub mod pallet {
 
 			loop {
 				let (result, weight) = Migration::<T>::migrate(remaining_weight);
-				remaining_weight.saturating_reduce(weight);
+				const reduced_weight_factor: u64 = 4;
+				let reduced_weight = match weight.checked_mul(4) {
+					Some(weight) => weight,
+					None => weight,
+				};
+				remaining_weight.saturating_reduce(reduced_weight);
 
 				match result {
 					// There is not enough weight to perform a migration, or make any progress, we

--- a/substrate/frame/contracts/src/lib.rs
+++ b/substrate/frame/contracts/src/lib.rs
@@ -411,13 +411,9 @@ pub mod pallet {
 			use migration::MigrateResult::*;
 
 			loop {
-				let (result, weight) = Migration::<T>::migrate(remaining_weight);
 				const reduced_weight_factor: u64 = 4;
-				let reduced_weight = match weight.checked_mul(4) {
-					Some(weight) => weight,
-					None => weight,
-				};
-				remaining_weight.saturating_reduce(reduced_weight);
+				let (result, weight) = Migration::<T>::migrate(remaining_weight.saturating_div(reduced_weight_factor));
+				remaining_weight.saturating_reduce(weight.saturating_mul(reduced_weight_factor));
 
 				match result {
 					// There is not enough weight to perform a migration, or make any progress, we


### PR DESCRIPTION
* Obviously `(x / 4) * 4` == `x` is not always true in integer division, but since we use saturated methods we should be fine
* With that change, https://github.com/Cardinal-Cryptography/aleph-node/pull/1610 migrations took 4x more time (expected) on my laptop, so in total 4 minutes, but chain was even visually less loaded